### PR TITLE
Install with "pip" seems broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to the documentation for the Python SDK for the Data Layer by Syntropy! 
 To install the Python SDK for Data Layer, you can use pip, the Python package manager. Here's an example of how to install it:
 
 ```shell
-pip install syntropynet-pubsub
+pip install git+https://github.com/Synternet/pubsub-python.git
 ```
 
 # Getting Started


### PR DESCRIPTION
When running the command suggested I got:

local:modus-api vsevolod_mineev$ pip install syntropynet-pubsub ERROR: Could not find a version that satisfies the requirement syntropynet-pubsub (from versions: none) ERROR: No matching distribution found for syntropynet-pubsub

However I was able to install like so:

pip install git+https://github.com/Synternet/pubsub-python.git

## Description
Install via pip from this repository.

## Related Issue
Pip is broken

## Proposed Changes
List the specific changes or additions made in this PR.

- Changed a single string in the readme

## Additional Info
Just seeing where I am, no need to actually merge.

## Checklist
- [y] I have tested these changes locally
- [y] I have reviewed the code for any potential issues
- [y] I have documented any necessary changes

