### PR TITLE
Synternet pubsub examples update

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of Conduct - Syntropy PubSub Python
+# Code of Conduct - Synternet PubSub Python
 
 ## Our Pledge
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # PubSub Python
 
-Welcome to the documentation for the Python SDK for the Data Layer by Syntropy! This SDK allows seamless integration with our Data Layer solution, enabling you to leverage real-time data streams in your Python applications. With the Python SDK, you can unlock the power of the Data Layer and harness real-time insights for your data-driven projects.
+Welcome to the documentation for the Python SDK for the Data Layer by Synternet! This SDK allows seamless integration with our Data Layer solution, enabling you to leverage real-time data streams in your Python applications. With the Python SDK, you can unlock the power of the Data Layer and harness real-time insights for your data-driven projects.
 
-[pubsub-python](https://github.com/SyntropyNet/pubsub-python) is a Python example illustrating the use of the Syntropy Data Layer project, which facilitates subscription to existing data streams or publishing new ones. This example employs the NATS messaging system and offers a simpler starting point for integrating Python applications with the Syntropy Data Layer platform.
+[pubsub-python](https://github.com/Synternet/pubsub-python) is a Python example illustrating the use of the Synternet Data Layer project, which facilitates subscription to existing data streams or publishing new ones. This example employs the NATS messaging system and offers a simpler starting point for integrating Python applications with the Synternet Data Layer platform.
 
 # Installation
 
 To install the Python SDK for Data Layer, you can use pip, the Python package manager. Here's an example of how to install it:
 
 ```shell
-pip install syntropynet-pubsub
+pip install git+https://github.com/Synternet/pubsub-python.git
 ```
 
 # Getting Started
 
-Before you begin using the Python SDK, make sure you have the necessary credentials and access tokens from the Syntropy [Developer Portal](https://developer-portal.syntropynet.com/) platform. These credentials will allow you to connect to the Data Layer and subscribe to or publish data streams.
+Before you begin using the Python SDK, make sure you have the necessary credentials and access tokens from the Synternet [Developer Portal](https://portal.synternet.com/) platform. These credentials will allow you to connect to the Data Layer and subscribe to or publish data streams.
 
 ## Examples
 
-For detailed usage examples, please refer to the [examples directory](https://github.com/SyntropyNet/pubsub-python/examples) in the repository. These examples cover various scenarios and demonstrate how to utilize the SDK's features effectively.
+For detailed usage examples, please refer to the [examples directory](https://github.com/Synternet/pubsub-python/examples) in the repository. These examples cover various scenarios and demonstrate how to utilize the SDK's features effectively.
 
-The preferred authentication method is using an access token from the [developer portal](https://developer-portal.syntropynet.com/).
+The preferred authentication method is using an access token from the [developer portal](https://portal.synternet.com/).
 
 ```Text Python
 import asyncio
@@ -30,10 +30,10 @@ import os
 
 from helper import create_app_jwt
 
-access_token = "EXAMPLE_ACCESS_TOKEN"
+ACCESS_TOKEN = "EXAMPLE_ACCESS_TOKEN"
 
 async def main():
-    jwt = create_app_jwt(access_token)
+    jwt = create_app_jwt(ACCESS_TOKEN)
 
     # Write the JWT to a temporary file with correct format
     with tempfile.NamedTemporaryFile(mode='w+t', delete=False) as temp:
@@ -47,7 +47,6 @@ async def main():
         data = msg.data.decode()
         print("Received a message on '{subject}: {data}".format(
             subject=subject, data=data))
-        # await nc.publish("syntropy.test.subject", msg.data)
 
     await nc.subscribe("syntropy.bitcoin.tx", cb=message_handler)
 
@@ -66,7 +65,7 @@ if __name__ == '__main__':
 ```
 
 # Contributing
-We welcome contributions from the community! If you find any issues or have suggestions for improvements, please open an issue or submit a pull request on the [GitHub repository](https://github.com/SyntropyNet/pubsub-python). We appreciate your feedback and collaboration in making this SDK even better. 
+We welcome contributions from the community! If you find any issues or have suggestions for improvements, please open an issue or submit a pull request on the [GitHub repository](https://github.com/Synternet/pubsub-python). We appreciate your feedback and collaboration in making this SDK even better. 
 
 ## Contribution Guidelines
 

--- a/publish.py
+++ b/publish.py
@@ -5,7 +5,7 @@ async def main():
     nc = await nats.connect("nats://127.0.0.1", user_credentials="nats.creds")
 
     for i in range(1000):
-        await nc.publish("my_publisher.example.subject", (str(i) + "x ").encode('utf-8'))
+        await nc.publish("publisher.example.subject", (str(i) + "x ").encode('utf-8'))
         await asyncio.sleep(1)
 
     # Terminate connection to NATS.

--- a/publish.py
+++ b/publish.py
@@ -5,7 +5,7 @@ async def main():
     nc = await nats.connect("nats://127.0.0.1", user_credentials="nats.creds")
 
     for i in range(1000):
-        await nc.publish("syntropy.test.subject", (str(i) + "x ").encode('utf-8'))
+        await nc.publish("my_publisher.example.subject", (str(i) + "x ").encode('utf-8'))
         await asyncio.sleep(1)
 
     # Terminate connection to NATS.

--- a/republish_using_creds_files.py
+++ b/republish_using_creds_files.py
@@ -12,7 +12,7 @@ async def main():
         data = msg.data.decode()
         print("Received a message on '{subject}: {data}".format(
             subject=subject, data=data))
-        await pub_nc.publish("my_republisher.example.subject", msg.data)
+        await pub_nc.publish("republisher.example.subject", msg.data)
 
     await sub_nc.subscribe("synternet.example.subject", cb=message_handler)
 

--- a/republish_using_creds_files.py
+++ b/republish_using_creds_files.py
@@ -1,28 +1,24 @@
 import asyncio
 import nats
 
+NATS_URL = "nats://127.0.0.1"
 
 async def main():
-    nc = await nats.connect("nats://127.0.0.1", user_credentials="nats.creds")
+    sub_nc = await nats.connect(NATS_URL, user_credentials="subscriber_nats.creds")
+    pub_nc = await nats.connect(NATS_URL, user_credentials="publisher_nats.creds")
 
     async def message_handler(msg):
         subject = msg.subject
         data = msg.data.decode()
         print("Received a message on '{subject}: {data}".format(
             subject=subject, data=data))
-        await nc.publish("syntropy.test.subject", msg.data)
+        await pub_nc.publish("my_republisher.example.subject", msg.data)
 
-    await nc.subscribe("syntropy.bitcoin.tx", cb=message_handler)
+    await sub_nc.subscribe("synternet.example.subject", cb=message_handler)
 
     # run infinitely
     while True:
         await asyncio.sleep(1)
-
-    # Remove interest in subscription.
-    await sub.unsubscribe()
-
-    # Terminate connection to NATS.
-    await nc.drain()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nats.py==2.2.0
-nkeys==0.1.0
+nkeys==0.2.1
 

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name="synternet-pubsub",
-    version="0.1",
+    version="0.2",
     py_modules=["helper"],
     packages=find_packages(),
     install_requires=[
         "nats.py==2.9.0",
-        "nkeys==0.1.0"
+        "nkeys==0.2.1"
     ],
     description="A helper package for Synternet DL",
     author="Synternet",

--- a/subscribe_with_seed.py
+++ b/subscribe_with_seed.py
@@ -1,14 +1,14 @@
-import asyncio
-import nats
-import tempfile
 import os
+import asyncio
+import tempfile
+import nats
 
 from helper import create_app_jwt
 
-access_token = "EXAMPLE_ACCESS_TOKEN"
+ACCESS_TOKEN = "EXAMPLE_ACCESS_TOKEN"
 
 async def main():
-    jwt = create_app_jwt(access_token)
+    jwt = create_app_jwt(ACCESS_TOKEN)
 
     # Write the JWT to a temporary file with correct format
     with tempfile.NamedTemporaryFile(mode='w+t', delete=False) as temp:
@@ -22,9 +22,8 @@ async def main():
         data = msg.data.decode()
         print("Received a message on '{subject}: {data}".format(
             subject=subject, data=data))
-        # await nc.publish("syntropy.test.subject", msg.data)
 
-    await nc.subscribe("syntropy.bitcoin.tx", cb=message_handler)
+    await nc.subscribe("synternet.xample.subject", cb=message_handler)
 
     # run infinitely
     while True:

--- a/subscribe_with_seed.py
+++ b/subscribe_with_seed.py
@@ -23,7 +23,7 @@ async def main():
         print("Received a message on '{subject}: {data}".format(
             subject=subject, data=data))
 
-    await nc.subscribe("synternet.xample.subject", cb=message_handler)
+    await nc.subscribe("synternet.example.subject", cb=message_handler)
 
     # run infinitely
     while True:


### PR DESCRIPTION
## Description
Updating python package version. Renewed URL links in README file. Rework of given example scripts: changing variable names for better understanding, complete rework of "republish_using_creds_files.py" file - used deprecated scenarios so changes were made according to available actions. at Synternet Portal.

## Proposed Changes
List the specific changes or additions made in this PR.

- Python 'nkeys' package version changed from 0.1.0 to 0.2.1 (was failing on 0.1.0)
- Updated URL links/naming in README (Updated everything to the current Synternet name)
- Example scripts update:
   publish.py: subject naming change (for easier understanding and unification between other pubsub repos)
   republish_using_creds_files.py: complete re-do. Instead of one NATS jwt and connection usage to subscribe and publish again - switched to two separate connections/jwt usage.  Synternet restrict NATS creds only to perform 1 type of action so now 1st CREDS will be used for publisher and 2nd for subscriber only

## Checklist
- [X] I have tested these changes locally
- [X] I have reviewed the code for any potential issues
- [X] I have documented any necessary changes

